### PR TITLE
Change setup for Varia TechDocs

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,8 @@ metadata:
   description: appsec.equinor.com
   annotations:
     github.com/project-slug: "equinor/appsec"
-    backstage.io/techdocs-ref: dir:./docs      
+    backstage.io/techdocs-ref: dir:.
+    equinor.com/techdocs-builder: host
   links:
     - url: 'https://appsec.equinor.com/'
       title: 'Official Equinor AppSec Website'


### PR DESCRIPTION
* Change `backstage.io/techdocs-ref` to point to the folder for `mkdocs.yaml` (which is repo root)
* Add `equinor.com/techdocs-builder: host` to let Varia build TechDocs for this repo.

Once this is merged and proves to work, the GitHub TechDocs workflow can be deleted.